### PR TITLE
security#mitigations: init module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,1 +1,1 @@
-[ ./services/torrent/qbittorrent.nix ]
+[ ./services/torrent/qbittorrent.nix ./security/mitigations.nix ]

--- a/modules/security/mitigations.nix
+++ b/modules/security/mitigations.nix
@@ -1,0 +1,50 @@
+{ config, lib, options, ... }:
+with lib;
+let
+  inherit (builtins) readFile fetchurl;
+
+  cfg = config.security.mitigations;
+
+  cmdline = readFile (fetchurl {
+    url = "https://make-linux-fast-again.com";
+    sha256 = "sha256:10diw5xn5jjx79nvyjqcpdpcqihnr3y0756fsgiv1nq7w28ph9w6";
+  });
+in {
+  options = {
+    security.mitigations.disable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to disable spectre and meltdown mitigations in the kernel. Do
+        not use this in mission critical deployments, or on any machine you do
+        not have physical access to.
+      '';
+    };
+
+    security.mitigations.acceptRisk = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        To ensure users know what they are doing, they must explicitly accept
+        the risk of turning off mitigations by enabling this.
+      '';
+    };
+  };
+
+  config = mkIf cfg.disable {
+    assertions = [{
+      assertion = cfg.acceptRisk;
+      message = ''
+        You have enabled 'security.mitigations.disable' without accepting the
+        risk of disabling mitigations.
+
+        You must explicitly accept the risk of running the kernel without
+        Spectre or Meltdown mitigations. Set 'security.mitigations.acceptRisk'
+        to 'true' only if you know what your doing!
+      '';
+    }];
+
+    boot.kernelParams = splitString " " cmdline;
+
+  };
+}

--- a/profiles/misc/default.nix
+++ b/profiles/misc/default.nix
@@ -1,3 +1,1 @@
-{ ... }: {
-  imports = [ ./stubby.nix ./adblocking.nix ./make-linux-fast-again.nix ];
-}
+{ ... }: { imports = [ ./stubby.nix ./adblocking.nix ]; }

--- a/profiles/misc/disable-mitigations.nix
+++ b/profiles/misc/disable-mitigations.nix
@@ -1,0 +1,1 @@
+{ ... }: { security.mitigations.disable = true; }

--- a/profiles/misc/make-linux-fast-again.nix
+++ b/profiles/misc/make-linux-fast-again.nix
@@ -1,9 +1,0 @@
-# file: make-linux-fast-again.nix
-{ pkgs, config, ... }:
-let
-  inherit (builtins) readFile fetchurl;
-  cmdline = readFile (fetchurl {
-    url = "https://make-linux-fast-again.com";
-    sha256 = "sha256:10diw5xn5jjx79nvyjqcpdpcqihnr3y0756fsgiv1nq7w28ph9w6";
-  });
-in { boot.kernelParams = pkgs.lib.splitString " " cmdline; }


### PR DESCRIPTION
Resolves #6 by breaking out the disabling of mitigations into it's own module.
Now users must explicitly accept the risk of disabling Spectre and Meltdown
mitigations with `security.mitigations.acceptRisk` in addtion to actually
disabling them with `security.mitigations.disable`.