### PR TITLE
flake: initial NUR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Introduction
 A NixOS configuration template using the experimental [flakes][rfc] mechanism.
 Its aim is to provide a generic repository which neatly separates concerns
-and allows one to get up and running with NixOS faster than ever.
+and allows one to get up and running with NixOS faster than ever. In addition,
+conveniences like [home-manager][home-manager] and [NUR][nur] are wired in by
+default to help make life easier.
 
 Flakes are still an experimental feature, but once they finally get merged
 even more will become possible, i.e. [nixops](https://nixos.org/nixops)
@@ -34,7 +36,6 @@ nixos-generate-config --show-hardware-config > ./hosts/${new_host}.nix
 # Also ensure your file systems are set the way you want. And import
 # any ./profiles you may wish to try out.
 $EDITOR ./hosts/${new_host}.nix
-
 
 # backup existing config and ensure configuration lives in expected location
 mv /etc/nixos /etc/nixos.old
@@ -94,6 +95,26 @@ this flake exports multiple outputs for use in other flakes:
 }
 
 ```
+
+### NUR usage
+
+You can use packages, modules and overlays from the
+[Nix User Repository][nur].
+
+For modules and overlays, you can pull them in via the new top-level arguements
+`nurModules` and `nurOverlays`, respectively:
+
+```nix
+{ nurModules, nurOverlays, pkgs, ... }:
+{
+  # ...
+  imports = [ nurModules."${nur-username}.modules.${aModule}" ];
+  nixpkgs.overlays = [ nurOverlays."${nur-username}".overlays."${anOverlay}" ];
+}
+```
+
+Packages are installable the same way as without flakes via
+`pkgs.nur."${nur-username}"."${aPackage}"`.
 
 # Structure
 
@@ -206,6 +227,7 @@ licenses of the respective packages.
 [direnv]: https://direnv.net
 [home-manager]: https://github.com/rycee/home-manager
 [NixOS]: https://nixos.org
+[nur]: https://github.com/nix-community/NUR
 [old]: https://github.com/nrdxp/nixos
 [pr]:  https://github.com/NixOS/nixpkgs/pull/68897
 [rfc]: https://github.com/tweag/rfcs/blob/flakes/rfcs/0049-flakes.md

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,7 +1,7 @@
 # this file is an impure recreation of the flake profile currently deployed
 # based on the systems hostname. The purpose is so tools which do not yet have
 # flake support (e.g `nixos-option`), can work as expected.
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   inherit (builtins) attrNames readDir;
 
@@ -30,5 +30,12 @@ in {
   nixpkgs.overlays = let
     overlays = map (name: import (./overlays + "/${name}"))
       (attrNames (readDir ./overlays));
-  in overlays;
+  in overlays ++ [
+    (final: prev: {
+      nur = import (builtins.fetchTarball
+        "https://github.com/nix-community/NUR/archive/master.tar.gz") {
+          inherit pkgs;
+        };
+    })
+  ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,19 @@
             "narHash": "sha256-4p9gqMJTVmyH7eSq1euGZWusldWoBfKfi/VwZEPL2Mw=",
             "originalUrl": "github:nrdxp/nixpkgs/fork",
             "url": "github:nrdxp/nixpkgs/1e232452ed4c57e9968f4342d9ba044d36403928"
+        },
+        "nur": {
+            "inputs": {
+                "nixpkgs": {
+                    "inputs": {},
+                    "narHash": "sha256-4p9gqMJTVmyH7eSq1euGZWusldWoBfKfi/VwZEPL2Mw=",
+                    "originalUrl": "nixpkgs",
+                    "url": "github:nrdxp/nixpkgs/1e232452ed4c57e9968f4342d9ba044d36403928"
+                }
+            },
+            "narHash": "sha256-i+NZZWnhNcxl73e2FjfgKUn3sW42ZKiVeXNKv72MN14=",
+            "originalUrl": "github:nrdxp/NUR/flake",
+            "url": "github:nrdxp/NUR/c632e4112b19a1b2fa05242a8cc971091d12e154"
         }
     },
     "version": 3

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,9 @@
 
   inputs.nixpkgs.url = "github:nrdxp/nixpkgs/fork";
   inputs.home.url = "github:nrdxp/home-manager/flakes";
+  inputs.nur.url = "github:nrdxp/NUR/flake";
 
-  outputs = args@{ self, home, nixpkgs }:
+  outputs = args@{ self, home, nixpkgs, nur }:
     let
       inherit (builtins) listToAttrs baseNameOf attrNames readDir;
       inherit (nixpkgs.lib) removeSuffix;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -11,6 +11,8 @@ let
       system = "x86_64-linux";
 
       specialArgs.usr = utils;
+      specialArgs.nurModules = args.nur.nixosModules;
+      specialArgs.nurOverlays = args.nur.overlays;
 
       modules = let
         core = ../profiles/core.nix;
@@ -24,7 +26,7 @@ let
           ];
           system.configurationRevision = self.rev;
 
-          nixpkgs.overlays = self.overlays;
+          nixpkgs.overlays = self.overlays ++ [ args.nur.overlay ];
         };
 
         local = import "${toString ./.}/${this}.nix";


### PR DESCRIPTION
Fixes #8 by importing a NUR as a flake input. Modules are accessible from `nurModules` and overlays from `nurOverlays` from within any NixOS module. In addition packages can be install with the usual `nur.repos.$user.$package`.