### PR TITLE
initial multiArch support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1605370193,
+        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -78,6 +93,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "home": "home",
         "master": "master",
         "nixos": "nixos",

--- a/flake.nix
+++ b/flake.nix
@@ -6,15 +6,17 @@
       master.url = "nixpkgs/master";
       nixos.url = "nixpkgs/release-20.09";
       home.url = "github:nix-community/home-manager/release-20.09";
+      flake-utils.url = "github:numtide/flake-utils";
     };
 
-  outputs = inputs@{ self, home, nixos, master, nur }:
+  outputs = inputs@{ self, home, nixos, master, flake-utils, nur }:
     let
-      inherit (builtins) attrNames attrValues readDir;
+      inherit (builtins) attrNames attrValues readDir elem;
+      inherit (flake-utils.lib) eachDefaultSystem;
       inherit (nixos) lib;
-      inherit (lib) removeSuffix recursiveUpdate genAttrs filterAttrs;
+      inherit (lib) all removeSuffix recursiveUpdate genAttrs filterAttrs;
       inherit (utils) pathsToImportedAttrs genPkgset overlayPaths modules
-        genPackages;
+        genPackages pkgImport;
 
       utils = import ./lib/utils.nix { inherit lib; };
 
@@ -27,33 +29,57 @@
         genPkgset {
           inherit master nixos overlays system;
         };
+
+      outputs = {
+        nixosConfigurations =
+          import ./hosts (recursiveUpdate inputs {
+            inherit lib pkgset system utils;
+          });
+
+        overlay = import ./pkgs;
+
+        overlays = pathsToImportedAttrs overlayPaths;
+
+        nixosModules = modules;
+
+        templates.flk.path = ./.;
+
+        templates.flk.description = "flk template";
+
+        defaultTemplate = self.templates.flk;
+      };
     in
-    with pkgset;
-    {
-      nixosConfigurations =
-        import ./hosts (recursiveUpdate inputs {
-          inherit lib pkgset system utils;
-        });
+    (eachDefaultSystem (system':
+      let
+        pkgs' = pkgImport {
+          pkgs = nixos;
+          system = system';
+          overlays = [ ];
+        };
+      in
+      {
+        devShell = import ./shell.nix {
+          pkgs = pkgs';
+        };
 
-      devShell."${system}" = import ./shell.nix {
-        pkgs = osPkgs;
-      };
+        packages =
+          let
+            packages' = genPackages {
+              overlay = self.overlay;
+              overlays = self.overlays;
+              pkgs = pkgs';
+            };
 
-      overlay = import ./pkgs;
-
-      overlays = pathsToImportedAttrs overlayPaths;
-
-      packages."${system}" = genPackages {
-        overlay = self.overlay;
-        overlays = self.overlays;
-        pkgs = osPkgs;
-      };
-
-      nixosModules = modules;
-
-      templates.flk.path = ./.;
-      templates.flk.description = "flk template";
-
-      defaultTemplate = self.templates.flk;
-    };
+            filtered = filterAttrs
+              (_: v:
+                (v.meta ? platforms)
+                && (elem system' v.meta.platforms)
+                && (
+                  (all (dev: dev.meta ? platforms) v.buildInputs)
+                  && (all (dev: elem system' dev.meta.platforms) v.buildInputs)
+                ))
+              packages';
+          in
+          filtered;
+      })) // outputs;
 }

--- a/pkgs/applications/blockchains/miningcore/default.nix
+++ b/pkgs/applications/blockchains/miningcore/default.nix
@@ -98,6 +98,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/akshaynexus/miningcore";
     license = licenses.mit;
     maintainers = with maintainers; [ nrdxp ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/applications/display-managers/sddm/themes/chili/default.nix
+++ b/pkgs/applications/display-managers/sddm/themes/chili/default.nix
@@ -19,10 +19,11 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
+    inherit version;
     description = "The hottest theme around for SDDM";
     homepage = "https://github.com/MarianArlt/sddm-chili";
     maintainers = [ maintainers.nrdxp ];
     license = licenses.gpl3;
-    inherit version;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/steamcompmgr/default.nix
+++ b/pkgs/applications/window-managers/steamcompmgr/default.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/steamos-compositor-plus";
     maintainers = [ maintainers.nrdxp ];
     license = licenses.bsd2;
+    platforms = platforms.linux;
     inherit version;
   };
 }

--- a/pkgs/data/fonts/dejavu-nerdfont/default.nix
+++ b/pkgs/data/fonts/dejavu-nerdfont/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ryanoasis/nerd-fonts";
     license = licenses.mit;
     maintainers = [ maintainers.nrdxp ];
+    platforms = platforms.unix;
     inherit version;
   };
 }

--- a/pkgs/misc/drivers/wii-u-gc-adapter/default.nix
+++ b/pkgs/misc/drivers/wii-u-gc-adapter/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ToadKing/wii-u-gc-adapter";
     maintainers = [ maintainers.nrdxp ];
     license = licenses.mit;
+    platforms = platforms.linux;
     inherit version;
   };
 }

--- a/pkgs/shells/zsh/pure/default.nix
+++ b/pkgs/shells/zsh/pure/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
     description = "Pretty, minimal and fast ZSH prompt";
     homepage = "https://github.com/sindresorhus/pure";
     maintainers = [ maintainers.nrdxp ];
+    platforms = platforms.unix;
     license = licenses.mit;
     inherit version;
   };

--- a/pkgs/shells/zsh/purs/default.nix
+++ b/pkgs/shells/zsh/purs/default.nix
@@ -33,6 +33,7 @@ buildRustPackage {
     homepage = "https://github.com/xcambar/purs";
     maintainers = [ maintainers.nrdxp ];
     license = licenses.mit;
+    platforms = platforms.unix;
     inherit version;
   };
 }


### PR DESCRIPTION
This should resolve #17 and fix #34. NixOS is only supported on x86 Linux, so this does not affect nixosConfigurations. This only affects the `devShell` and `package` outputs. NixOS is pinned to x86_64 for now.

Every package is tested to ensure it is compatible with a given system based on its platform metadata _before_ it it added to that systems package set.