### PR TITLE
Add extraArgs to lib.nixosSystem call to add system args

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -68,6 +68,9 @@ let
         in
         flakeModules ++ [ core global local home-manager overrides ];
 
+      extraArgs = {
+        inherit system;
+      };
     };
 
   hosts = recImport {


### PR DESCRIPTION
As flakes cannot use `builtins.currentSystem`, there is no way as for now to use packages from a flake using `builtins.getFlake` because we need to pass a system to the result. (e.g. `myFlake.packages.x86_64-linux.myPackage`)

If we check the source code of [`lib.nixosSystem`](https://github.com/NixOS/nixpkgs/blob/3743c42f23767dca657f1a5d3eb67945e373ff94/flake.nix), we can see that `args` is passed to [`./nixos/lib/eval-config.nix`](https://github.com/NixOS/nixpkgs/blob/b77d8ead284c4193f84c82d2fcd4a3aa11fbf158/nixos/lib/eval-config.nix). In that file, `extraArgs` is defined, which says that args passed through this attribute will be distributed to each module loaded.

With my contribution, we can add system to defined nixos modules.