### PR TITLE
update to 20.09 to fix segfault

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,16 +5,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1591751635,
-        "narHash": "sha256-KgGtyFlkI/fsp+j8VEgJ/ynY9B91aX35Xp04HlDLRTo=",
-        "owner": "rycee",
+        "lastModified": 1604441492,
+        "narHash": "sha256-Wo7WqdwNQnWHmhyZuhVLrAEpCuZl88cA9ttxkiCTekY=",
+        "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b3fee796fcd5531693d9b84ece76ad6836bb1cfa",
+        "rev": "63f299b3347aea183fc5088e4d6c4a193b334a41",
         "type": "github"
       },
       "original": {
-        "owner": "rycee",
-        "ref": "bqv-flakes",
+        "owner": "nix-community",
+        "ref": "release-20.09",
         "repo": "home-manager",
         "type": "github"
       }
@@ -36,16 +36,16 @@
     },
     "nixos": {
       "locked": {
-        "lastModified": 1596329181,
-        "narHash": "sha256-q6NSFQnFbpey/RP2LFfYW9Vcpt6CYKO8Q//6TuNBuYM=",
+        "lastModified": 1606876313,
+        "narHash": "sha256-vxY4MK/Gm8NI2DW+btbXkN93KJ5eBEcI/eqAqRXTgFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7dc4385dc7b5b2c0dbfecd774cebbc87ac05c061",
+        "rev": "eef919eb47583d4932dac3ecac0d7bc71f24b645",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "release-20.03",
+        "ref": "release-20.09",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,8 @@
   inputs =
     {
       master.url = "nixpkgs/master";
-      nixos.url = "nixpkgs/release-20.03";
-      home.url = "github:rycee/home-manager/bqv-flakes";
+      nixos.url = "nixpkgs/release-20.09";
+      home.url = "github:nix-community/home-manager/release-20.09";
     };
 
   outputs = inputs@{ self, home, nixos, master }:


### PR DESCRIPTION
Also fixes #24 by using recommended home-manager

Now this error happens though:

```shell
rebuild niximg test
evaluating file '/nix/store/2qc98g8pw1yv3kvh1yczwdjazgj14rw4-nix-2.4pre20200721_ff314f1/share/nix/corepkgs/derivation.nix'
evaluating file '/nix/store/bn1v0x4df7ai5xz20ynjhpxwjsbz3kqi-source/flake.nix'
evaluating file '/nix/store/bn1v0x4df7ai5xz20ynjhpxwjsbz3kqi-source/hosts/default.nix'

... snip ...

evaluating file '/nix/store/9ify4gaqcpnxqwb7alkspwxqhzicrpgi-source/pkgs/os-specific/linux/wpa_supplicant/default.nix'
evaluating file '/nix/store/9ify4gaqcpnxqwb7alkspwxqhzicrpgi-source/pkgs/os-specific/linux/udisks/2-default.nix'
evaluating file '/nix/store/9ify4gaqcpnxqwb7alkspwxqhzicrpgi-source/nixos/modules/installer/tools/nixos-option/default.nix'
evaluating file '/nix/store/9ify4gaqcpnxqwb7alkspwxqhzicrpgi-source/pkgs/development/tools/misc/strace/default.nix'
error: --- ThrownError ------------------------------------------------------------------- nix
cquery has been removed because it is abandoned by upstream. Consider switching to clangd or ccls instead.
(use '--show-trace' to show detailed location information)
```

I'm not sure how to address that issue but I see that kakoune.nix uses cquery. Just removing cquery didn't seem to fix the issue though.