### PR TITLE
flake: clean up by moving implementation to utils

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -74,8 +74,8 @@ directly from this flake via `nixosModules.cachix.<your-cachix>`.
 All expressions in both [modules/list.nix](modules/list.nix) and
 [pkgs/default.nix](pkgs/default.nix) are available globally, anywhere else in the
 repo. They are additionally included in the `nixosModules` and `overlay` flake
-outputs, respectively. Packages can manually be added to [flake.nix](flake.nix)
-for inclusion in the `packages` output as well.
+outputs, respectively. Packages are automatically included in the `packages`
+output as well.
 
 The directory structure is identical to nixpkgs to provide a kind of staging area
 for any modules or packages we might be wanting to merge there later. If your not
@@ -87,5 +87,9 @@ They will be automatically pulled in for use by all configurations. Nix command
 line tools will be able to read overlays from here as well since it is set as
 `nixpkgs-overlays` in `NIX_PATH`. And of course they will be exported via the
 flake output `overlays` as well.
+
+If you wish to use an overlay from an external flake, simply add it to the
+`externOverlays` list in the `let` block of the `outputs` attribute in
+[flake.nix](flake.nix).
 
 [home-manager]: https://github.com/rycee/home-manager

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -11,7 +11,7 @@
 let
   inherit (utils) recImport;
   inherit (builtins) attrValues removeAttrs;
-  inherit (pkgset) osPkgs pkgs;
+  inherit (pkgset) osPkgs unstablePkgs;
 
   config = hostName:
     lib.nixosSystem {
@@ -37,7 +37,7 @@ let
                 "home-manager=${home}"
               ];
 
-            nixpkgs = { pkgs = osPkgs; };
+            nixpkgs.pkgs = osPkgs;
 
             nix.registry = {
               master.flake = master;
@@ -52,7 +52,7 @@ let
           overrides = {
             nixpkgs.overlays =
               let
-                override = import ../pkgs/override.nix pkgs;
+                override = import ../pkgs/override.nix unstablePkgs;
 
                 overlay = pkg: final: prev: {
                   "${pkg.pname}" = pkg;

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -2,7 +2,8 @@
 let
   inherit (builtins) attrNames isAttrs readDir listToAttrs;
 
-  inherit (lib) filterAttrs hasSuffix mapAttrs' nameValuePair removeSuffix;
+  inherit (lib) filterAttrs hasSuffix mapAttrs' nameValuePair removeSuffix
+    recursiveUpdate genAttrs;
 
   # mapFilterAttrs ::
   #   (name -> value -> bool )
@@ -13,21 +14,11 @@ let
   # Generate an attribute set by mapping a function over a list of values.
   genAttrs' = values: f: listToAttrs (map f values);
 
-in
-{
-  inherit mapFilterAttrs genAttrs';
-
-  recImport = { dir, _import ? base: import "${dir}/${base}.nix" }:
-    mapFilterAttrs
-      (_: v: v != null)
-      (n: v:
-        if n != "default.nix" && hasSuffix ".nix" n && v == "regular"
-        then
-          let name = removeSuffix ".nix" n; in nameValuePair (name) (_import name)
-
-        else
-          nameValuePair ("") (null))
-      (readDir dir);
+  pkgImport = { pkgs, system, overlays }:
+    import pkgs {
+      inherit system overlays;
+      config = { allowUnfree = true; };
+    };
 
   # Convert a list to file paths to attribute set
   # that has the filenames stripped of nix extension as keys
@@ -37,5 +28,69 @@ in
       name = removeSuffix ".nix" (baseNameOf path);
       value = import path;
     });
+
+in
+{
+  inherit mapFilterAttrs genAttrs' pkgImport pathsToImportedAttrs;
+
+  genPkgset = { master, nixos, overlays, system }:
+    {
+      osPkgs = pkgImport {
+        inherit system overlays;
+        pkgs = nixos;
+      };
+
+      unstablePkgs = pkgImport {
+        inherit system overlays;
+        pkgs = master;
+      };
+    };
+
+  overlayPaths =
+    let
+      overlayDir = ../overlays;
+      fullPath = name: overlayDir + "/${name}";
+    in
+    map fullPath (attrNames (readDir overlayDir));
+
+  recImport = { dir, _import ? base: import "${dir}/${base}.nix" }:
+    mapFilterAttrs
+      (_: v: v != null)
+      (n: v:
+        if n != "default.nix" && hasSuffix ".nix" n && v == "regular"
+        then
+          let name = removeSuffix ".nix" n; in nameValuePair (name) (_import name)
+        else
+          nameValuePair ("") (null))
+      (readDir dir);
+
+  modules =
+    let
+      # binary cache
+      cachix = import ../cachix.nix;
+      cachixAttrs = { inherit cachix; };
+
+      # modules
+      moduleList = import ../modules/list.nix;
+      modulesAttrs = pathsToImportedAttrs moduleList;
+
+      # profiles
+      profilesList = import ../profiles/list.nix;
+      profilesAttrs = { profiles = pathsToImportedAttrs profilesList; };
+    in
+    recursiveUpdate
+      (recursiveUpdate cachixAttrs modulesAttrs)
+      profilesAttrs;
+
+  genPackages = { overlay, overlays, pkgs }:
+    let
+      packages = overlay pkgs pkgs;
+      overlays' = lib.filterAttrs (n: v: n != "pkgs") overlays;
+      overlayPkgs =
+        genAttrs
+          (attrNames overlays')
+          (name: (overlays'."${name}" pkgs pkgs)."${name}");
+    in
+    recursiveUpdate packages overlayPkgs;
 
 }


### PR DESCRIPTION
Fixes #28 by adding an `externOverlays` list to easily import overlays from external flakes.

In general, the flake.nix was becoming pretty messy.