### PR TITLE
flake: add `externModules` list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
       system = "x86_64-linux";
 
       externOverlays = [ nur.overlay ];
+      externModules = [ home.nixosModules.home-manager ];
 
       pkgset =
         let overlays = (attrValues self.overlays) ++ externOverlays; in
@@ -33,7 +34,7 @@
       outputs = {
         nixosConfigurations =
           import ./hosts (recursiveUpdate inputs {
-            inherit lib pkgset system utils;
+            inherit lib pkgset system utils externModules;
           });
 
         overlay = import ./pkgs;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -6,6 +6,7 @@
 , self
 , system
 , utils
+, externModules
 , ...
 }:
 let
@@ -19,8 +20,6 @@ let
 
       modules =
         let
-          inherit (home.nixosModules) home-manager;
-
           core = self.nixosModules.profiles.core;
 
           global = {
@@ -68,7 +67,7 @@ let
             attrValues (removeAttrs self.nixosModules [ "profiles" ]);
 
         in
-        flakeModules ++ [ core global local home-manager overrides ];
+        flakeModules ++ [ core global local overrides ] ++ externModules;
 
       extraArgs = {
         inherit system;


### PR DESCRIPTION
Fixes #44. Easily add external modules from other flakes by dropping them in the list.