### PR TITLE
Revert "Add extraArgs to lib.nixosSystem call to add system args."

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -69,9 +69,6 @@ let
         in
         flakeModules ++ [ core global local overrides ] ++ externModules;
 
-      extraArgs = {
-        inherit system;
-      };
     };
 
   hosts = recImport {


### PR DESCRIPTION
Fix #46 by reverting commit 684804ebe026aaad2c6bbcff2166222ebff124d8.

If you need the value of `system`, use `pkgs.system` instead.