### PR TITLE
ref: remove overlay xref to pkgs

### DIFF
--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -85,11 +85,10 @@ in
   genPackages = { overlay, overlays, pkgs }:
     let
       packages = overlay pkgs pkgs;
-      overlays' = lib.filterAttrs (n: v: n != "pkgs") overlays;
       overlayPkgs =
         genAttrs
-          (attrNames overlays')
-          (name: (overlays'."${name}" pkgs pkgs)."${name}");
+          (attrNames overlays)
+          (name: (overlays."${name}" pkgs pkgs)."${name}");
     in
     recursiveUpdate packages overlayPkgs;
 

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -1,1 +1,0 @@
-../pkgs/default.nix


### PR DESCRIPTION
since packages are exposed through output.packages by their own,
a second export through overlays.pkgs would be smudging the public api
of this repository.