### PR TITLE
update home-manager urls

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -92,4 +92,4 @@ If you wish to use an overlay from an external flake, simply add it to the
 `externOverlays` list in the `let` block of the `outputs` attribute in
 [flake.nix](flake.nix). Same for external modules, add them to `externModules`.
 
-[home-manager]: https://github.com/rycee/home-manager
+[home-manager]: https://github.com/nix-community/home-manager

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ licenses of the respective packages.
 
 [bare]: https://github.com/nrdxp/nixflk/tree/bare
 [direnv]: https://direnv.net
-[home-manager]: https://github.com/rycee/home-manager
+[home-manager]: https://github.com/nix-community/home-manager
 [nix-command]: https://nixos.wiki/wiki/Nix_command
 [nixFlakes]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/package-management/nix/default.nix#L211
 [NixOS]: https://nixos.org

--- a/configuration.nix
+++ b/configuration.nix
@@ -19,7 +19,7 @@ in
   imports = (import ./modules/list.nix) ++ [
     "${
       builtins.fetchTarball
-        "https://github.com/rycee/home-manager/archive/master.tar.gz"
+        "https://github.com/nix-community/home-manager/archive/master.tar.gz"
       }/nixos"
     /etc/nixos/profiles/core
   ] ++ config;


### PR DESCRIPTION
HM moved to nix-community on Github. There is a 301 redirect, but I have no idea how long it will stay up, so it's better not to rely on it.

Things done:
- [x] Grep for rycee
- [x] Click both links on Github to make sure that they work
- [x] Test configuration with `NIXOS_CONFIG=$PWD/configuration.nix nixos-option`
- [x] Run `nixpkgs-fmt --check configuration.nix`