### PR TITLE
Make modules overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,11 @@
       externModules = [ home.nixosModules.home-manager ];
 
       pkgset =
-        let overlays = (attrValues self.overlays) ++ externOverlays; in
+        let overlays =
+          (attrValues self.overlays)
+          ++ externOverlays
+          ++ [ self.overlay ];
+        in
         genPkgset {
           inherit master nixos overlays system;
         };

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -14,6 +14,8 @@ let
   inherit (builtins) attrValues removeAttrs;
   inherit (pkgset) osPkgs unstablePkgs;
 
+  unstableModules = [ ];
+
   config = hostName:
     lib.nixosSystem {
       inherit system;
@@ -26,6 +28,13 @@ let
       modules =
         let
           core = self.nixosModules.profiles.core;
+
+          modOverrides = { config, unstableModulesPath, ... }: {
+            disabledModules = unstableModules;
+            imports = map
+              (path: "${unstableModulesPath}/${path}")
+              unstableModules;
+          };
 
           global = {
             home-manager.useGlobalPkgs = true;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -18,6 +18,11 @@ let
     lib.nixosSystem {
       inherit system;
 
+      specialArgs =
+        {
+          unstableModulesPath = "${master}/nixos/modules";
+        };
+
       modules =
         let
           core = self.nixosModules.profiles.core;

--- a/hosts/niximg.nix
+++ b/hosts/niximg.nix
@@ -1,10 +1,10 @@
-{ modulesPath, ... }: {
+{ unstableModulesPath, ... }: {
   imports = [
     # passwd is nixos by default
     ../users/nixos
     # passwd is empty by default
     ../users/root
-    "${modulesPath}/installer/cd-dvd/iso-image.nix"
+    "${unstableModulesPath}/installer/cd-dvd/iso-image.nix"
   ];
 
   isoImage.makeEfiBootable = true;


### PR DESCRIPTION
We should be able to pull modules from master in a pinch. Just place a relative module path name in the `unstableModules` list in `hosts/default.nix`, it will be overriden.

For modules which are not included by default, such as the installable iso image modules, they can be pulled from anywhere via `unstableModulesPath`.

Fixes #63.