### PR TITLE
Instruct reloading nix shell after changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ a template. There is a [bare branch][bare] if you want to start with a
 completely empty template and make your own profiles from scratch. The only
 hard requirement is nix itself. The `shell.nix` will pull in everything else.
 
+When using nix shell for building your system generation, after a change you
+need to exit and re-enter the nix-shell.
+
 ## Flake Templates
 If you already have [nix-command][nix-command] setup you can:
 ```sh


### PR DESCRIPTION
At least in my case, adding https://github.com/nrdxp/nixflk/pull/74/files required leaving and re-entering (`nix develop`) the nix shell for the override to take effect.

Maybe there is a better way to alert & inform the user. It seems to be always necesary to reload.

Or alternatively: maybe best solution would be to do the required re-instantiation directly within `flk` command, since re-entering the nix shell is a bit awkward UX