### PR TITLE
Evaluate exported pkgs against repo baseline nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
         let
           pkgs = pkgImport {
             inherit system;
-            pkgs = master;
+            pkgs = nixos;
             overlays = [ devshell.overlay ];
           };
 


### PR DESCRIPTION
The baseline pkgs for own consumption is nixos, only pkgs/override.nix
provides a mechanism to "backport" packages from unstable.

Therefore, we should expose our packages to others in the same
context as we use them ourselves.

---

I was about to open an issue, yet I figured it would be more helpful to directly propose a PR, instead. Maybe this needs more preliminary discussion, though.

See also #76 (part about `master` vs `nixos` overlays)

---

Proporsal together with #78 

fix #76 