### PR TITLE
Don't evaluate overlays on master

### DIFF
--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -41,7 +41,8 @@ in
       };
 
       unstablePkgs = pkgImport {
-        inherit system overlays;
+        inherit system;
+        overlays = [];
         pkgs = master;
       };
     };


### PR DESCRIPTION
master is only used in the context of `pkgs/override.nix`
and `unstableModulesPath`
and only within `./hosts`

Since [overlays exists that are incompatible between nixos and master
at evaluation time (sic!)](https://github.com/nrdxp/nixflk/issues/63#issuecomment-757566201), this together with #77 avoids evaluating
overlays against master all together.

---

Proposal to

fix #76 