### PR TITLE
shell: add `flk up` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 result
+up
+hosts/up-*
 .direnv

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ flk install yourConfig # deploys hosts/yourConfig.nix
 flk yourConfig switch
 ```
 
+### Note on `flk up`:
+While the `up` sub-command is provided as a convenience to quickly set up and
+install a "fresh" NixOS system on current hardware, committing these files is
+discouraged.
+
+They are placed in the git staging area automatically because they would be
+invisible to the flake otherwise, but it is best to move what you need from
+them directly into your hosts file and commit that instead.
+
 ## Build an ISO
 
 You can make an ISO and customize it by modifying the [niximg](./hosts/niximg.nix)

--- a/README.md
+++ b/README.md
@@ -104,12 +104,9 @@ for ease of use. Once inside:
 # This will setup nix-command and pull in the needed tools
 nix-shell # or `direnv allow` if you prefer
 
-# quick way to setup your fileSystems (assuming they are partioned):
-sudo mount /dev/<install-drive> /mnt
-nixos-generate-config --root /mnt --show-hardware-config > hosts/yourConfig.nix
-
-# Edit your config to add a bootloader
-$EDITOR hosts/yourConfig.nix
+# use nixos-generate-config to generate a basic config for your system
+# edit hosts/up-$(hostname).nix to modify.
+flk up
 
 # The following should work fine for EFI systems.
 # boot.loader.systemd-boot.enable = true;

--- a/shell.nix
+++ b/shell.nix
@@ -17,7 +17,14 @@ let
 
   flk = pkgs.writeShellScriptBin "flk" ''
     if [[ -z "$1" ]]; then
-      echo "Usage: $(basename "$0") [ iso | install {host} | {host} [switch|boot|test] ]"
+      echo "Usage: $(basename "$0") [ iso | up | install {host} | {host} [switch|boot|test] ]"
+    elif [[ "$1" == "up" ]]; then
+      mkdir -p up
+      nixos-generate-config --dir up
+      echo \
+      "{
+      imports = [ ../up/configuration.nix ];
+    }" > hosts/up-$(hostname).nix
     elif [[ "$1" == "iso" ]]; then
       nix build ${configs}.niximg.${build}.isoImage
     elif [[ "$1" == "install" ]]; then

--- a/shell.nix
+++ b/shell.nix
@@ -20,11 +20,14 @@ let
       echo "Usage: $(basename "$0") [ iso | up | install {host} | {host} [switch|boot|test] ]"
     elif [[ "$1" == "up" ]]; then
       mkdir -p up
-      nixos-generate-config --dir up
+      hostname=$(hostname)
+      nixos-generate-config --dir up/$hostname
       echo \
       "{
-      imports = [ ../up/configuration.nix ];
-    }" > hosts/up-$(hostname).nix
+      imports = [ ../up/$hostname/configuration.nix ];
+    }" > hosts/up-$hostname.nix
+    git add -f up/$hostname
+    git add -f hosts/up-$hostname.nix
     elif [[ "$1" == "iso" ]]; then
       nix build ${configs}.niximg.${build}.isoImage
     elif [[ "$1" == "install" ]]; then


### PR DESCRIPTION
Automatically generate a configuration for your current system using nixos-generate-config, placed in the `up` directory. A file is added in hosts/up-$(hostname).nix importing said configuration.

Useful for getting up and running quickly, but if the user intends to use more than one host, they should probably move the generated bits directly into their host config manually.
 
@blaggacao, would appreciate your input.