### PR TITLE
Hosts: fix mod override

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -15,6 +15,7 @@ let
   inherit (pkgset) osPkgs unstablePkgs;
 
   unstableModules = [ ];
+  addToDisabledModules = [ ];
 
   config = hostName:
     lib.nixosSystem {
@@ -30,7 +31,7 @@ let
           core = self.nixosModules.profiles.core;
 
           modOverrides = { config, unstableModulesPath, ... }: {
-            disabledModules = unstableModules;
+            disabledModules = unstableModules ++ addToDisabledModules;
             imports = map
               (path: "${unstableModulesPath}/${path}")
               unstableModules;


### PR DESCRIPTION
In some occasions the module path was renamed.
To avoid conflicts, the old path must be disabled manually.

E.g.
```nix
{
  unstableModules = [
    "services/ttys/getty.nix"
  ];
  addToDisabledModules = [
    "services/ttys/agetty.nix"
  ];
}
```