### PR TITLE
settings: initial toml configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,23 +14,23 @@
 
   outputs = inputs@{ self, home, nixos, master, flake-utils, nur, devshell }:
     let
-      inherit (builtins) attrNames attrValues elem pathExists;
+      inherit (builtins) attrNames attrValues elem fromTOML pathExists;
       inherit (flake-utils.lib) eachDefaultSystem mkApp flattenTreeSystem;
       inherit (nixos) lib;
-      inherit (lib) recursiveUpdate filterAttrs mapAttrs;
+      inherit (lib) recursiveUpdate filterAttrs fileContents mapAttrs;
       inherit (utils) pathsToImportedAttrs genPkgset overlayPaths modules
         genPackages pkgImport;
 
       utils = import ./lib/utils.nix { inherit lib; };
+      settings = fromTOML (fileContents ./settings.toml);
 
       externOverlays = [ nur.overlay devshell.overlay ];
       externModules = [ home.nixosModules.home-manager ];
 
-      osSystem = "x86_64-linux";
 
       outputs =
         let
-          system = osSystem;
+          inherit (settings) system;
           pkgset =
             let
               overlays =
@@ -45,7 +45,7 @@
         {
           nixosConfigurations =
             import ./hosts (recursiveUpdate inputs {
-              inherit lib pkgset utils externModules system;
+              inherit lib pkgset utils externModules settings;
             });
 
           overlay = import ./pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -27,25 +27,27 @@
       externOverlays = [ nur.overlay devshell.overlay ];
       externModules = [ home.nixosModules.home-manager ];
 
+      pkgs' = unstable:
+        let
+          override = import ./pkgs/override.nix;
+          overlays = (attrValues self.overlays)
+            ++ externOverlays
+            ++ [ self.overlay (override unstable) ];
+        in
+        pkgImport nixos overlays;
+
+      unstable' = pkgImport master [ ];
 
       outputs =
         let
           inherit (settings) system;
-          pkgset =
-            let
-              overlays =
-                (attrValues self.overlays)
-                ++ externOverlays
-                ++ [ self.overlay ];
-            in
-            genPkgset {
-              inherit master nixos overlays system;
-            };
+          unstablePkgs = unstable' system;
+          osPkgs = pkgs' unstablePkgs system;
         in
         {
           nixosConfigurations =
             import ./hosts (recursiveUpdate inputs {
-              inherit lib pkgset utils externModules settings;
+              inherit lib osPkgs unstablePkgs utils externModules settings;
             });
 
           overlay = import ./pkgs;
@@ -65,11 +67,8 @@
       (eachDefaultSystem
         (system:
           let
-            pkgs = pkgImport {
-              inherit system;
-              pkgs = nixos;
-              overlays = [ devshell.overlay ];
-            };
+            unstablePkgs = unstable' system;
+            pkgs = pkgs' unstablePkgs system;
 
             packages = flattenTreeSystem system
               (genPackages {

--- a/hosts/NixOS.nix
+++ b/hosts/NixOS.nix
@@ -1,7 +1,4 @@
 {
-  ### root password is empty by default ###
-  imports = [ ../users/nixos ../users/root ];
-
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -24,8 +24,8 @@ let
 
       specialArgs =
         {
+          inherit settings;
           unstableModulesPath = "${master}/nixos/modules";
-          settings = fromTOML (readFile ../settings.toml);
         };
 
       modules =

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -11,7 +11,7 @@
 }:
 let
   inherit (utils) recImport;
-  inherit (builtins) attrValues removeAttrs;
+  inherit (builtins) attrValues fromTOML readFile removeAttrs;
   inherit (pkgset) osPkgs unstablePkgs;
 
   unstableModules = [ ];
@@ -24,6 +24,7 @@ let
       specialArgs =
         {
           unstableModulesPath = "${master}/nixos/modules";
+          settings = fromTOML (readFile ../settings.toml);
         };
 
       modules =

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -4,7 +4,7 @@
 , master
 , pkgset
 , self
-, system
+, settings
 , utils
 , externModules
 , ...
@@ -13,6 +13,7 @@ let
   inherit (utils) recImport;
   inherit (builtins) attrValues fromTOML readFile removeAttrs;
   inherit (pkgset) osPkgs unstablePkgs;
+  inherit (settings) system;
 
   unstableModules = [ ];
   addToDisabledModules = [ ];

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -15,8 +15,8 @@ let
   inherit (builtins) attrValues fromTOML readFile removeAttrs;
   inherit (settings) system;
 
-  unstableModules = [ ];
-  addToDisabledModules = [ ];
+  unstableModules = settings.modules.unstable;
+  addToDisabledModules = settings.modules.disabled;
 
   config = hostName:
     lib.nixosSystem {
@@ -31,6 +31,16 @@ let
       modules =
         let
           core = self.nixosModules.profiles.core;
+
+          profiles =
+            let
+              inherit (settings.meta) machine machines;
+            in
+            {
+              imports = map
+                (profile: self.nixosModules.profiles.${profile})
+                machines.${machine} or [ ];
+            };
 
           modOverrides = { config, unstableModulesPath, ... }: {
             disabledModules = unstableModules ++ addToDisabledModules;
@@ -76,6 +86,7 @@ let
           core
           global
           local
+          profiles
           modOverrides
         ] ++ externModules;
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -2,9 +2,10 @@
 , lib
 , nixos
 , master
-, pkgset
+, osPkgs
 , self
 , settings
+, unstablePkgs
 , utils
 , externModules
 , ...
@@ -12,7 +13,6 @@
 let
   inherit (utils) recImport;
   inherit (builtins) attrValues fromTOML readFile removeAttrs;
-  inherit (pkgset) osPkgs unstablePkgs;
   inherit (settings) system;
 
   unstableModules = [ ];
@@ -65,14 +65,6 @@ let
             system.configurationRevision = lib.mkIf (self ? rev) self.rev;
           };
 
-          overrides = {
-            nixpkgs.overlays =
-              let
-                override = import ../pkgs/override.nix unstablePkgs;
-              in
-              [ override ];
-          };
-
           local = import "${toString ./.}/${hostName}.nix";
 
           # Everything in `./modules/list.nix`.
@@ -84,7 +76,6 @@ let
           core
           global
           local
-          overrides
           modOverrides
         ] ++ externModules;
 

--- a/hosts/niximg.nix
+++ b/hosts/niximg.nix
@@ -1,9 +1,5 @@
 { unstableModulesPath, ... }: {
   imports = [
-    # passwd is nixos by default
-    ../users/nixos
-    # passwd is empty by default
-    ../users/root
     "${unstableModulesPath}/installer/cd-dvd/iso-image.nix"
   ];
 

--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 let
-  inherit (builtins) attrNames isAttrs readDir listToAttrs;
+  inherit (builtins) attrNames attrValues isAttrs mapAttrs readDir listToAttrs;
 
-  inherit (lib) filterAttrs hasSuffix mapAttrs' nameValuePair removeSuffix
+  inherit (lib) fold filterAttrs hasSuffix mapAttrs' nameValuePair removeSuffix
     recursiveUpdate genAttrs;
 
   # mapFilterAttrs ::
@@ -14,8 +14,8 @@ let
   # Generate an attribute set by mapping a function over a list of values.
   genAttrs' = values: f: listToAttrs (map f values);
 
-  pkgImport = { pkgs, system, overlays }:
-    import pkgs {
+  pkgImport = nixpkgs: overlays: system:
+    import nixpkgs {
       inherit system overlays;
       config = { allowUnfree = true; };
     };
@@ -32,20 +32,6 @@ let
 in
 {
   inherit mapFilterAttrs genAttrs' pkgImport pathsToImportedAttrs;
-
-  genPkgset = { master, nixos, overlays, system }:
-    {
-      osPkgs = pkgImport {
-        inherit system overlays;
-        pkgs = nixos;
-      };
-
-      unstablePkgs = pkgImport {
-        inherit system;
-        overlays = [];
-        pkgs = master;
-      };
-    };
 
   overlayPaths =
     let
@@ -86,12 +72,19 @@ in
   genPackages = { self, pkgs }:
     let
       inherit (self) overlay overlays;
-      packages = overlay pkgs pkgs;
-      overlayPkgs =
-        genAttrs
-          (attrNames overlays)
-          (name: (overlays."${name}" pkgs pkgs)."${name}");
+      packagesNames = attrNames (overlay null null)
+        ++ attrNames (fold
+        (attr: sum: recursiveUpdate sum attr)
+        { }
+        (attrValues
+          (mapAttrs (_: v: v null null) overlays)
+        )
+      );
     in
-    recursiveUpdate packages overlayPkgs;
-
+    fold
+      (key: sum: recursiveUpdate sum {
+        ${key} = pkgs.${key};
+      })
+      { }
+      packagesNames;
 }

--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -1,13 +1,17 @@
-{ config, lib, pkgs, ... }:
-let inherit (lib) fileContents;
-
+{ config, lib, pkgs, settings, ... }:
+let
+  inherit (lib) fileContents;
+  inherit (settings) users;
 in
 {
   nix.package = pkgs.nixFlakes;
 
   nix.systemFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
 
-  imports = [ ../../local/locale.nix ];
+  imports = [
+    ../../local/locale.nix
+    (../../users + "/${users.interactive}")
+  ];
 
   environment = {
 

--- a/profiles/graphical/default.nix
+++ b/profiles/graphical/default.nix
@@ -1,5 +1,7 @@
-{ pkgs, ... }:
-let inherit (builtins) readFile;
+{ pkgs, settings, ... }:
+let
+  inherit (builtins) readFile;
+  inherit (settings) users;
 in
 {
   imports = [ ./sway ../develop ./xmonad ../network ./im ];
@@ -88,4 +90,6 @@ in
       theme = "chili";
     };
   };
+
+  users.users."${users.interactive}".extraGroups = [ "input" ];
 }

--- a/profiles/graphical/plex.nix
+++ b/profiles/graphical/plex.nix
@@ -1,4 +1,8 @@
-{ ... }: {
+{ settings, ... }:
+let
+  inherit (settings) users;
+in
+{
   services.plex = {
     enable = true;
     dataDir = "/srv/plex";
@@ -7,4 +11,6 @@
   };
 
   users.groups.media.members = [ "plex" ];
+
+  users.users."${users.interactive}".extraGroups = [ "media" ];
 }

--- a/profiles/network/networkmanager/default.nix
+++ b/profiles/network/networkmanager/default.nix
@@ -1,4 +1,8 @@
-{ lib, ... }: {
+{ lib, settings, ... }:
+let
+  inherit (settings) users;
+in
+{
   networking.networkmanager = {
     enable = true;
     wifi.backend = "iwd";
@@ -22,4 +26,6 @@
       DNSOverTLS=yes
     '';
   };
+
+  users.users."${users.interactive}".extraGroups = [ "networkmanager" ];
 }

--- a/profiles/network/torrent.nix
+++ b/profiles/network/torrent.nix
@@ -1,7 +1,8 @@
-{ config, lib, ... }:
+{ config, lib, settings, ... }:
 let
   inherit (config.services.qbittorrent) port;
   inherit (lib) mkAfter;
+  inherit (settings) users;
 in
 {
   services.qbittorrent = {
@@ -11,6 +12,8 @@ in
   };
 
   users.groups.media.members = [ "qbittorrent" ];
+
+  users.users."${users.interactive}".extraGroups = [ "media" ];
 
   environment.etc."xdg/qutebrowser/config.py".text = mkAfter ''
     c.url.searchengines['to'] = 'https://torrentz2.eu/search?f={}'

--- a/profiles/virt/default.nix
+++ b/profiles/virt/default.nix
@@ -1,4 +1,8 @@
-{ pkgs, ... }: {
+{ pkgs, settings, ... }:
+let
+  inherit (settings) users;
+in
+{
   virtualisation = {
     libvirtd = {
       enable = true;
@@ -23,4 +27,6 @@
   environment.sessionVariables = {
     VAGRANT_DEFAULT_PROVIDER = "libvirt";
   };
+
+  users.users."${users.interactive}".extraGroups = [ "libvirtd" ];
 }

--- a/settings.toml
+++ b/settings.toml
@@ -2,3 +2,16 @@ system = "x86_64-linux"
 
 [users]
 interactive = "nixos"
+
+[modules]
+unstable = [ ]
+disabled = [ ]
+
+[meta]
+machine = "work"
+
+[meta.machines]
+work = [
+  "develop",
+  "virt"
+]

--- a/settings.toml
+++ b/settings.toml
@@ -1,2 +1,4 @@
+system = "x86_64-linux"
+
 [users]
 interactive = "nixos"

--- a/settings.toml
+++ b/settings.toml
@@ -1,0 +1,2 @@
+[users]
+interactive = "nixos"

--- a/users/nixos/default.nix
+++ b/users/nixos/default.nix
@@ -1,5 +1,5 @@
 {
-  imports = [ ../../profiles/develop ];
+  imports = [ ../../profiles/develop ../root ];
 
   home-manager.users.nixos = {
     imports = [ ../profiles/git ../profiles/direnv ];


### PR DESCRIPTION
Create a `settings.toml` file for easily setting configuration wide dependant options. Includes the example of setting the interactive user via this file.

Profiles requires introspective knowledge of the user configuration which is not normally available. The example, implemented here, is the interactive system user. Some profiles need to add this user to a specific group. 

Previously we relied on the users profile to keep track of, and add these users to the required groups. Now, a profile can pull the currently declared username from `settings.users.interactive` and add that user to the required groups. This improves profiles ability to provide a hermetic configuration for specific applications, while simultaneously simplifying configuration for new users.

Pull in settings from any NixOS module like so:
```nix
{ settings, ... }:
{
  users.users."${settings.users.interactive}" = {
    # ...
  };
}
```
Definitely want some feedback before committing to a final spec.
@blaggacao @jtojnar @bbigras @lourkeur @codygman @adamscott 