### PR TITLE
users: Initial home-manager only configurations(non-nixos systems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,43 @@ They are placed in the git staging area automatically because they would be
 invisible to the flake otherwise, but it is best to move what you need from
 them directly into your hosts file and commit that instead.
 
+## Home Manager Integration
+The home-manager nixos module is available for each host. It is meant
+to be used in the user profiles, you can find an example in the nixos user profile
+
+The home-manager configuration for each user in each system is available in the
+outputs as homeConfigurations and the activation packages in hmActivationPackages.
+
+This allows you to just build the home-manager environment without the rest of the
+system configuration. The feature is useful on systems without nixos or root access.
+
+Lets say you want to activate the home configuration for the user `nixos` in the 
+host `NixOS`.
+
+With the flk script:
+```sh
+# You can build it using
+flk home NixOS nixos
+# and activate with
+./result/activate
+
+# Or do both like this
+flk home NixOS nixos switch
+```
+
+This can also be done manually:
+```sh
+
+# With hmActivationPackages, what the flk script uses
+nix build ./#hmActivationPackages.NixOS.nixos
+
+# Or with homeConfigurations, 
+nix build ./#homeConfigurations.NixOS.nixos.home.activationPackage
+# this is hard to debug though, due to nix build's fallback to packages
+
+# The configuration can then be activated like before
+```
+
 ## Build an ISO
 
 You can make an ISO and customize it by modifying the [niximg](./hosts/niximg.nix)

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -73,6 +73,15 @@ in
       (recursiveUpdate cachixAttrs modulesAttrs)
       profilesAttrs;
 
+  genHomeActivationPackages = hmConfigs: {
+    hmActivationPackages =
+      builtins.mapAttrs
+        (_: x: builtins.mapAttrs
+          (_: cfg: cfg.home.activationPackage)
+          x)
+        hmConfigs;
+  };
+
   genPackages = { self, pkgs }:
     let
       inherit (self) overlay overlays;

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -12,7 +12,7 @@ let
 
   flk = pkgs.writeShellScriptBin "flk" ''
     if [[ -z "$1" ]]; then
-      echo "Usage: $(basename "$0") [ iso | up | install {host} | {host} [switch|boot|test] ]"
+      echo "Usage: $(basename "$0") [ iso | up | install {host} | {host} [switch|boot|test] | home {host} {user} [switch] ]"
     elif [[ "$1" == "up" ]]; then
       mkdir -p $DEVSHELL_ROOT/up
       hostname=$(hostname)
@@ -27,6 +27,11 @@ let
       nix build $DEVSHELL_ROOT#nixosConfigurations.niximg.${build}.isoImage "${"\${@:2}"}"
     elif [[ "$1" == "install" ]]; then
       sudo nixos-install --flake "$DEVSHELL_ROOT#$2" "${"\${@:3}"}"
+    elif [[ "$1" == "home" ]]; then
+      nix build ./#hmActivationPackages.$2.$3
+      if [[ "$4" == "switch" ]]; then
+        ./result/activate && unlink result
+      fi
     else
       sudo nixos-rebuild --flake "$DEVSHELL_ROOT#$1" "${"\${@:2}"}"
     fi


### PR DESCRIPTION
Closes #83 

Working implementation of exporting home-manager only configurations. This exports to a non-official output of homeConfigurations, along with hmActivationPackages in the packages output. Both are an attrset of hosts then users

So if you were trying to build activationPackage for the host NixOS and user nixos, you can do:
`nix build ./#homeConfigurations.NixOS.nixos.home.activationPackage`
or 
`nix-build ./#hmActivation.NixOS.nixos'
    This ones easier for debugging, because nix build will default to the packages output if homeConfiguration has any error and it won't say when it does so.

The flk script can then use the activation package to activate the home-manager configuration(not implemented yet).

There are a few more things to add like local nix registry and config with xdg.configFile along with nix paths and other compatibility things.

TODO:
 - [x] Create homeConfiguration for each user in each system
 - [x] Export activation packages for each homeConfiguration
 - [x] Add support in flk wrapper script to easily build and switch home-manager configurations
 - [x] Document feature in readme
 <s>- [ ] Add some default modules/imports to all the homeConfigurations, preferably only in homeConfigurations and not for system configs. Not sure if this is even possible yet. This can include: nix paths, local nix.conf, and others in the future.</s>I think this can be done in the future, possibly along with adding custom modules feature to home-manager.

