### PR TITLE
flake/host: add nixos-hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ file:
 flk iso
 ```
 
+## Hardware Specific Profile for a Single Host
+
+Find out the fitting [nixos-hardware profile](https://github.com/NixOS/nixos-hardware#list-of-profiles) path for the hardware of your host and add it to the configuration.
+For example for a Dell XPS 13 9370 the host configuration would contain:
+```nix
+{
+  imports = [ "${hardwareModulesPath}/dell/xps/13-9370" ... ];
+  ...
+}
+```
+
 ## Use a Package from NUR
 
 NUR is wired in from the start. For safety, nothing is added from it by default,

--- a/flake.lock
+++ b/flake.lock
@@ -80,6 +80,21 @@
         "type": "indirect"
       }
     },
+    "nixos-hardware": {
+      "locked": {
+        "lastModified": 1610430373,
+        "narHash": "sha256-2sTBiGl0z0B3VD2qMHIJtOGxOuftR0iiBSv30AhVWIw=",
+        "owner": "nixos",
+        "repo": "nixos-hardware",
+        "rev": "874830945a65ad1134aff3a5aea0cdd2e1d914ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1607981906,
@@ -114,6 +129,7 @@
         "home": "home",
         "master": "master",
         "nixos": "nixos",
+        "nixos-hardware": "nixos-hardware",
         "nur": "nur"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,10 @@
       home.url = "github:nix-community/home-manager/release-20.09";
       flake-utils.url = "github:numtide/flake-utils/flatten-tree-system";
       devshell.url = "github:numtide/devshell";
+      nixos-hardware.url = "github:nixos/nixos-hardware";
     };
 
-  outputs = inputs@{ self, home, nixos, master, flake-utils, nur, devshell }:
+  outputs = inputs@{ self, home, nixos, master, flake-utils, nur, devshell, nixos-hardware }:
     let
       inherit (builtins) attrNames attrValues elem pathExists;
       inherit (flake-utils.lib) eachDefaultSystem mkApp flattenTreeSystem;

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -2,6 +2,7 @@
 , lib
 , nixos
 , master
+, nixos-hardware
 , pkgset
 , self
 , system
@@ -24,6 +25,7 @@ let
       specialArgs =
         {
           unstableModulesPath = "${master}/nixos/modules";
+          hardwareModulesPath = "${nixos-hardware}";
         };
 
       modules =


### PR DESCRIPTION
- add nixos-hardware flake.
- configuration in hosts/default.nix to be able to include hardware
specifics per host.
- add corresponding documentation in readme