### PR TITLE
nixos-hardware: use the flake instead of a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ flk iso
 
 ## Hardware Specific Profile for a Single Host
 
-Find out the fitting [nixos-hardware profile](https://github.com/NixOS/nixos-hardware#list-of-profiles) path for the hardware of your host, then find the corresponding modules in the [flake](https://github.com/NixOS/nixos-hardware/blob/master/flake.nix) and addit to the configuration.
+Find out the fitting [nixos-hardware profile](https://github.com/NixOS/nixos-hardware#list-of-profiles) for the hardware of your host, then find the corresponding modules in the [flake](https://github.com/NixOS/nixos-hardware/blob/master/flake.nix) and add it to the configuration.
 For example for a Dell XPS 13 9370 the host configuration would contain:
 ```nix
 {

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ flk iso
 
 ## Hardware Specific Profile for a Single Host
 
-Find out the fitting [nixos-hardware profile](https://github.com/NixOS/nixos-hardware#list-of-profiles) path for the hardware of your host and add it to the configuration.
+Find out the fitting [nixos-hardware profile](https://github.com/NixOS/nixos-hardware#list-of-profiles) path for the hardware of your host, then find the corresponding modules in the [flake](https://github.com/NixOS/nixos-hardware/blob/master/flake.nix) and addit to the configuration.
 For example for a Dell XPS 13 9370 the host configuration would contain:
 ```nix
 {
-  imports = [ "${hardwareModulesPath}/dell/xps/13-9370" ... ];
+  imports = [ hardware.dell-xps-13-9370 ... ];
   ...
 }
 ```

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -25,7 +25,7 @@ let
       specialArgs =
         {
           unstableModulesPath = "${master}/nixos/modules";
-          hardwareModulesPath = "${nixos-hardware}";
+          hardware = nixos-hardware.nixosModules;
         };
 
       modules =


### PR DESCRIPTION
Just after you merged my PR I realised there is also a more an approach to include nixos-hardware more inline with the idea of falkes.
This basically means no paths are need to include the hardware configuration and looks a bit cleaner in my opinion.