### PR TITLE
shell: use devshell-native pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
--   repo: https://github.com/nix-community/nixpkgs-fmt
-    rev: master
-    hooks:
-    -   id: nixpkgs-fmt

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "devshell": {
       "locked": {
-        "lastModified": 1611739118,
-        "narHash": "sha256-QjLEfLSiiWDdURFMkke/W7iJsA0unI3pg+91ubvmjbI=",
+        "lastModified": 1611764683,
+        "narHash": "sha256-RETUhdtMma4yBWzJECs2gCZmLlsyqyoXA/dUon3Hxic=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "d7a5ebc22aa89a40a96b413a8fc616178920567c",
+        "rev": "21f3cc1433ec257cc9b85c91e471d54f7f74f646",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "devshell": {
       "locked": {
-        "lastModified": 1607956014,
-        "narHash": "sha256-kcmh1ZO56GFYStDeM2VngJSvx/e8aKhFSYqLwfiq+Es=",
+        "lastModified": 1611739118,
+        "narHash": "sha256-QjLEfLSiiWDdURFMkke/W7iJsA0unI3pg+91ubvmjbI=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "17f46732ce299daa2977be2978f60d258c2d1b41",
+        "rev": "d7a5ebc22aa89a40a96b413a8fc616178920567c",
         "type": "github"
       },
       "original": {

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -34,7 +34,7 @@ let
 
   name = "flk";
 in
-pkgs.mkDevShell {
+pkgs.devshell.mkShell {
   inherit name;
 
   packages = with pkgs; with installPkgs; [
@@ -48,6 +48,28 @@ pkgs.mkDevShell {
 
   env = { inherit name; };
 
+  git.hooks = with pkgs; {
+    enable = true;
+    pre-commit.text = ''
+      if ${git}/bin/git rev-parse --verify HEAD >/dev/null 2>&1
+      then
+        against=HEAD
+      else
+        # Initial commit: diff against an empty tree object
+        against=$(${git}/bin/git hash-object -t tree /dev/null)
+      fi
+      # Redirect output to stderr.
+      exec 1>&2
+
+      # Format staged nix files.
+      exec ${nixpkgs-fmt}/bin/nixpkgs-fmt \
+        $(
+           ${git}/bin/git diff-index --name-only --cached $against -- \
+           | ${ripgrep}/bin/rg '\.nix$'
+         )
+    '';
+  };
+
   commands = with pkgs; [
     {
       name = nixpkgs-fmt.pname;
@@ -60,11 +82,6 @@ pkgs.mkDevShell {
       help = "Build, deploy, and install nixflk";
       category = "main";
       package = flk;
-    }
-    {
-      name = "hooks";
-      help = "install git hooks";
-      command = "pre-commit install";
     }
     {
       name = "grip";


### PR DESCRIPTION
Since https://github.com/numtide/devshell/pull/63, git hooks where introduced into deshell.

They better encapsulate the development environment than pre-commit does. Notably, they are under nix control not under pre-commit control.

@zimbatm looks good, first adoption attempt in the wild :+1: Thx!