### PR TITLE
deploy-rs: init support

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -23,4 +23,6 @@
   - [iso](./doc/flk/iso.md)
   - [install](./doc/flk/install.md)
   - [home](./doc/flk/home.md)
+- [Integrations](doc/integrations/index.md)
+  - [deploy-rs](./doc/integrations/deploy.md)
 - [Contributing](./doc/README.md)

--- a/doc/integrations/deploy.md
+++ b/doc/integrations/deploy.md
@@ -1,0 +1,49 @@
+# deploy-rs
+[Deploy-rs][d-rs] is a tool for managing NixOS remote machines. It was
+chosen for nixflk after the author experienced some frustrations with the
+stateful nature of nixops' db. It was also designed from scratch to support
+flake based deployments, and so is an excellent tool for the job.
+
+By default, all the [hosts](../../hosts) are also available as deploy-rs nodes,
+configured with the hostname set to `networking.hostName`; overridable via
+the command line.
+
+## Usage
+
+Just add your ssh key to the host:
+```nix
+{ ... }:
+{
+  users.users.${sshUser}.openssh.authorizedKeys.keyFiles = [
+    ../secrets/path/to/key.pub
+  ];
+}
+```
+
+And the private key to your user:
+```nix
+{ ... }:
+{
+  home-manager.users.${sshUser}.programs.ssh = {
+    enable = true;
+
+    matchBlocks = {
+      ${host} = {
+        host = hostName;
+        identityFile = ../secrets/path/to/key;
+        extraOptions = { AddKeysToAgent = "yes"; };
+      };
+    };
+  }
+}
+```
+
+And run the deployment:
+```sh
+deploy "flk#hostName" --hostname host.example.com
+```
+
+> ##### _Note:_
+> Your user will need sudo access
+
+[d-rs]: https://github.com/serokell/deploy-rs

--- a/doc/integrations/index.md
+++ b/doc/integrations/index.md
@@ -1,0 +1,5 @@
+# Integrations
+This section explores some of the optional tools included with nixflk to provide
+a solution to common concerns such as ci and remote deployment. An effort is
+made to choose tools that treat nix, and where possible flakes, as first class
+citizens.

--- a/extern/default.nix
+++ b/extern/default.nix
@@ -8,6 +8,9 @@
   overlays = [
     nur.overlay
     devshell.overlay
+    (final: prev: {
+      deploy-rs = deploy.packages.${prev.system}.deploy-rs;
+    })
   ];
 
   # passed to all nixos modules

--- a/flake.lock
+++ b/flake.lock
@@ -27,6 +27,35 @@
         "type": "github"
       }
     },
+    "deploy": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "naersk": [
+          "naersk"
+        ],
+        "nixpkgs": [
+          "override"
+        ],
+        "utils": [
+          "utils"
+        ]
+      },
+      "locked": {
+        "lastModified": 1612864896,
+        "narHash": "sha256-pbsvxe05kAWJzPeC6fs4t0Mk8mTZs6u/WQDMBqoA5tA=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "fecc7e723db40c7e056371467275186b3bbb9ef3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
     "devshell": {
       "locked": {
         "lastModified": 1612486691,
@@ -76,6 +105,26 @@
         "owner": "nix-community",
         "ref": "release-20.09",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "override"
+        ]
+      },
+      "locked": {
+        "lastModified": 1612192764,
+        "narHash": "sha256-7EnLtZQWP6511G1ZPA7FmJlqAr3hWsAYb24tvTvJ/ec=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "6e149bfd726a8ebefa415f2d713ba6d942435abd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
         "type": "github"
       }
     },
@@ -156,9 +205,11 @@
     "root": {
       "inputs": {
         "ci-agent": "ci-agent",
+        "deploy": "deploy",
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "home": "home",
+        "naersk": "naersk",
         "nixos": "nixos",
         "nixos-hardware": "nixos-hardware",
         "nur": "nur",

--- a/flake.nix
+++ b/flake.nix
@@ -14,25 +14,33 @@
       ci-agent.inputs.nixos-20_09.follows = "nixos";
       ci-agent.inputs.nixos-unstable.follows = "override";
       ci-agent.inputs.flake-compat.follows = "flake-compat";
+      deploy.url = "github:serokell/deploy-rs";
+      deploy.inputs.utils.follows = "utils";
+      deploy.inputs.naersk.follows = "naersk";
+      deploy.inputs.nixpkgs.follows = "override";
+      deploy.inputs.flake-compat.follows = "flake-compat";
+      naersk.url = "github:nmattia/naersk";
+      naersk.inputs.nixpkgs.follows = "override";
       flake-compat.url = "github:edolstra/flake-compat";
       flake-compat.flake = false;
     };
 
   outputs =
-    inputs@{ self
-    , ci-agent
+    inputs@{ ci-agent
+    , deploy
+    , devshell
     , home
     , nixos
-    , override
-    , utils
-    , nur
-    , devshell
     , nixos-hardware
+    , nur
+    , override
+    , self
+    , utils
     , ...
     }:
     let
       inherit (utils.lib) eachDefaultSystem flattenTreeSystem;
-      inherit (nixos.lib) recursiveUpdate;
+      inherit (nixos.lib) recursiveUpdate mapAttrs;
       inherit (self.lib) overlays nixosModules genPackages genPkgs
         genHomeActivationPackages;
 
@@ -63,6 +71,21 @@
           templates.flk.description = "flk template";
 
           defaultTemplate = self.templates.flk;
+
+          deploy.nodes = mapAttrs
+            (_: config: {
+              hostname = config.config.networking.hostName;
+
+              profiles.system = {
+                user = "root";
+                path = deploy.lib.x86_64-linux.activate.nixos config;
+              };
+            })
+            self.nixosConfigurations;
+
+          checks = builtins.mapAttrs
+            (system: deployLib: deployLib.deployChecks self.deploy)
+            deploy.lib;
         };
 
       systemOutputs = eachDefaultSystem (system:

--- a/flake.nix
+++ b/flake.nix
@@ -40,9 +40,9 @@
     }:
     let
       inherit (utils.lib) eachDefaultSystem flattenTreeSystem;
-      inherit (nixos.lib) recursiveUpdate mapAttrs;
+      inherit (nixos.lib) recursiveUpdate;
       inherit (self.lib) overlays nixosModules genPackages genPkgs
-        genHomeActivationPackages;
+        genHomeActivationPackages mkNodes;
 
       extern = import ./extern { inherit inputs; };
 
@@ -72,16 +72,7 @@
 
           defaultTemplate = self.templates.flk;
 
-          deploy.nodes = mapAttrs
-            (_: config: {
-              hostname = config.config.networking.hostName;
-
-              profiles.system = {
-                user = "root";
-                path = deploy.lib.x86_64-linux.activate.nixos config;
-              };
-            })
-            self.nixosConfigurations;
+          deploy.nodes = mkNodes deploy self.nixosConfigurations;
 
           checks = builtins.mapAttrs
             (system: deployLib: deployLib.deployChecks self.deploy)

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -43,6 +43,21 @@ let
     map fullPath (attrNames (readDir overlayDir));
 
   /**
+  Synopsis: mkNodes _nixosConfigurations_
+
+  Generate the `nodes` attribute expected by deploy-rs
+  where _nixosConfigurations_ are `nodes`.
+  **/
+  mkNodes = deploy: mapAttrs (_: config: {
+    hostname = config.config.networking.hostName;
+
+    profiles.system = {
+      user = "root";
+      path = deploy.lib.x86_64-linux.activate.nixos config;
+    };
+  });
+
+  /**
   Synopsis: importDefaults _path_
 
   Recursively import the subdirs of _path_ containing a default.nix.
@@ -72,7 +87,7 @@ let
 in
 {
   inherit importDefaults mapFilterAttrs genAttrs' pkgImport
-    pathsToImportedAttrs;
+    pathsToImportedAttrs mkNodes;
 
   overlays = pathsToImportedAttrs overlayPaths;
 

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,10 +1,18 @@
 let
-  inherit (default.inputs.nixos.lib) recurseIntoAttrs;
+  inherit (default.inputs.nixos.lib) mapAttrs recurseIntoAttrs;
 
   default = (import "${../.}/compat").defaultNix;
   packages = import ../default.nix;
 in
 {
+  checks = recurseIntoAttrs (mapAttrs (_: v: recurseIntoAttrs v) {
+    inherit (default.checks)
+      aarch64-linux
+      i686-linux
+      x86_64-linux
+      ;
+  });
+
   # platforms supported by our hercules-ci agent
   inherit (packages)
     aarch64-linux

--- a/profiles/core/default.nix
+++ b/profiles/core/default.nix
@@ -12,6 +12,7 @@ in
       binutils
       coreutils
       curl
+      deploy-rs
       direnv
       dnsutils
       dosfstools
@@ -22,8 +23,8 @@ in
       iputils
       jq
       manix
-      nix-index
       moreutils
+      nix-index
       nmap
       ripgrep
       tealdeer

--- a/shell/default.nix
+++ b/shell/default.nix
@@ -23,7 +23,7 @@ pkgs.devshell.mkShell {
     nixos-install
     nixos-generate-config
     nixos-enter
-  ];
+  ] ++ lib.optional (system == "x86_64-linux") deploy-rs;
 
   env = { inherit name; };
 


### PR DESCRIPTION
Managing servers remotely is a big usecase, and deploy-rs is a flake first deployment tool. By default, all nixosConfigurations are also setup as deploy-rs nodes.

You'll still need to do some manual ssh setup, but other than that, the system is ready to deploy.

- [x] initial deploy-rs support
- [x] add documentation
- [x] move deploy logic to lib